### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-search-extension",
-  "version": "1.0.0",
+  "version": "1.0.1,
   "description": "A cross-browser Brave Search extension.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
To apply description updates within the Edge store, the version number had to be bumped to 1.0.1. Bumping here as well so that future releases to all stores maintain the same version number.