### PR TITLE
fixes name only for chrome web store

### DIFF
--- a/src/manifest.jsonc
+++ b/src/manifest.jsonc
@@ -1,7 +1,15 @@
 {
   "manifest_version": 3,
   "author": "Brave Software",
-  "name": "Brave Search (official) - Private Search Engine",
+  /**
+   * Firefox's addons.mozilla.org requires a name that is no more than 45
+   * characters in length. Further, it permits the maintainer of the extension
+   * to provide an edited name after upload. The Chrome Web Store derives its
+   * listing directly from the extension manifest itself, and limits the name
+   * to 75 characters. For this reason we maintain two distinct names.
+   */
+  "firefox:name": "Brave Search",
+  "chromium:name": "Brave Search (official) - Private Search Engine",
   "description": "Configures Brave Search as the default search engine.",
   "version": "1.0.2",
   /**


### PR DESCRIPTION
The name shown on the Firefox Addons store is provided after the fact via an edit to the product listing. This is also the case for the Microsoft Store. Chrome's Web Store derives its name from the extension itself. As such, to have unity between all instances of the extension, the manifest file itself needs to be updated. But, due to a 45-character length restriction in the Firefox Addon store, we cannot use the longer name in the manifest file itself. The Chrome Web Store is limited to 75 characters for the name.