### PR TITLE
changes keyword to established convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-search-extension",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A cross-browser Brave Search extension.",
   "main": "index.js",
   "type": "module",

--- a/src/manifest.jsonc
+++ b/src/manifest.jsonc
@@ -64,7 +64,7 @@
        * "Brave" for simplicity.
        */
       "name": "Brave",
-      "keyword": "brave",
+      "keyword": "@brave",
       "encoding": "UTF-8",
       "search_url": "https://search.brave.com/search?q={searchTerms}",
       "suggest_url": "https://search.brave.com/api/suggest?q={searchTerms}",


### PR DESCRIPTION
While it's not uncommon for extensions to use a single word as their keyword, other conventions also exist: domains names, and short-hand handles using the @ character. Within the space of Brave Search extension users, there is greater familiarity with the short-hand convention, so we will be following that from now on. This is technically a major change, which merits bumping the version up to 2.0.0, since it breaks the previous "brave" keyword.